### PR TITLE
Fix broken links

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -178,7 +178,7 @@ vault groups: [default, MinecraftGroup1, MinecraftGroup2]
 
 ### Get Role ID(s) for the role(s) you want to sync  
 
-If you have `Developer Mode` enabled (see [Basic Installation](Installation#Basic-Installation)), you can get the IDs from `Server Settings > Roles` by right-clicking the role(s)  
+If you have `Developer Mode` enabled (see [Basic Installation](#basic-installation)), you can get the IDs from `Server Settings > Roles` by right-clicking the role(s)  
 
 Role IDs are also in the `discordsrv-info.txt` file of debug reports, which can be accessed through the link generated from `/discordsrv debug`  
 
@@ -204,7 +204,7 @@ That's the basics of it! Read the comments for the other options in the `synchro
 ## Voice Setup
 
 ***
-**Please make sure to go through the [Basic Installation](Installation#Basic-Installation) before going through with this setup.**
+**Please make sure to go through the [Basic Installation](#basic-installation) before going through with this setup.**
 ***
 
 Make sure `Voice enabled` is set to `true` in the `voice.yml` config
@@ -243,7 +243,7 @@ Lobby channel: 000000000000000000
 ## Require Linking to Join Setup 
 
 ***
-**Please make sure to go through the [Basic Installation](Installation#Basic-Installation) before going through with this setup.**
+**Please make sure to go through the [Basic Installation](#basic-installation) before going through with this setup.**
 ***
 
 This allows you to require the player have their discord account linked to their minecraft account before they can play on the server. When a player attempts to join, they get automatically kicked with a message saying that they need to message your DiscordSRV bot a code for them to be able to join.
@@ -253,10 +253,10 @@ Once the player is linked, more restrictions can be added, such as:
 - The linked player must be in the discord server
 - The linked player must have certain role[s] (this can be used to whitelist Twitch subscribers through the subscriber role if the user's twitch is linked to their discord account)
 
-Make sure `Enabled` is set to `true` in the [`linking.yml`](linking) config to enable this feature, then restart your server.
+Make sure `Enabled` is set to `true` in the [`linking.yml`](../linking) config to enable this feature, then restart your server.
 ```yaml
 # linking.yml Line 2
 Enabled: true
 ```
 
-Each option inside [`linking.yml`](linking) is explained using comments, so read through them to get a better understanding of what you can do.
+Each option inside [`linking.yml`](../linking) is explained using comments, so read through them to get a better understanding of what you can do.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -149,7 +149,7 @@ Make sure the new Bot role is above any roles you want to synchronize using our 
 ## Group <-> Role Sync
  
 ***
-**Please make sure to go through the [Basic Installation](Installation#Basic-Installation) before going through with this setup.**
+**Please make sure to go through the [Basic Installation](#basic-installation) before going through with this setup.**
 ***
  
 ### Get the name(s) of the minecraft group(s) you want to sync

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ Visit the [Installation](Installation) page for clear and in-depth instructions 
 ## Donations
 First off, thank you from the bottom of my heart for the pizza. If you would like to donate, go to https://scarsz.me/donate. $10 is the suggested amount but you can donate however much you would like- anything is a massive thank you from me. In the note put your Discord username and if you're in DiscordSRV's server you'll be set as a donator and you'll receive some neat perks in the future. If you donated without the note, send me a PM on Discord and I'll manually check it.  
 ## Developers
-If you want to interface DiscordSRV with your plugin, you can do so by adding the Maven dependency or adding the plugin jar (DiscordSRV version 1.18.0+) to your project. For an example of this, see [DiscordSRV-ApiTest](/DiscordSRV/DiscordSRV-ApiTest). Be sure to add "DiscordSRV" to your plugin's `plugin.yml` depends/softdepends list.  
+If you want to interface DiscordSRV with your plugin, you can do so by adding the Maven dependency or adding the plugin jar (DiscordSRV version 1.18.0+) to your project. For an example of this, see [DiscordSRV-ApiTest](https://github.com/DiscordSRV/DiscordSRV-ApiTest). Be sure to add "DiscordSRV" to your plugin's `plugin.yml` depends/softdepends list.  
 
 === "Maven"
     ```xml


### PR DESCRIPTION
This PR:
- Fixes the `DiscordSRV-ApiTest` link not working on the home page.
- Fixes the `#basic-installation` anchors from not working on the installation page.
- Fixes the link to redirect to the `linking` page from not working on the installation page.
