### PR TITLE
Update config.yml with new options

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -104,6 +104,8 @@ Note: DebugLevel is now deprecated
 ### [`CancelConsoleCommandIfLoggingFailed`](https://config.discordsrv.com/config/CancelConsoleCommandIfLoggingFailed) {id="CancelConsoleCommandIfLoggingFailed"}
 This option disables running a console command through discord if logging is unsuccessful.
 
+### [`EnableIncompatibleClientAlert`](https://config.discordsrv.com/config/EnableIncompatibleClientAlert) {id="EnableIncompatibleClientAlert"}
+LunarClient does not support hover/click components in messages. Users of LunarClient will receive an automated message stating that their user experience is worsened by the use of the client, if this option is enabled
 
 ### [`ForcedLanguage`](https://config.discordsrv.com/config/ForcedLanguage)[^1] {id="ForcedLanguage"}
 This option forcefully changes the language to the specified type.
@@ -868,6 +870,9 @@ Setting the timezone as `default` will set it to the system's timezone
     ```
 
 ---
+
+### [MinecraftMentionSound](https://config.discordsrv.com/config/MinecraftMentionSound) {id="MinecraftMentionSound"}
+Whether a sound should be sent to the player in Minecraft when they are mentioned from Discord
 
 ### DiscordChatChannel...
 


### PR DESCRIPTION
This PR adds the following config options:
* EnableIncompatibleClientAlert
* MinecraftMentionSound

Waiting on #21 before merging to move options to correctly ordered places